### PR TITLE
Add Go Local Bridge to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The plugin list is generated automatically from [this file](https://github.com/s
 - [Import from Microsoft ToDo](https://github.com/daylamtayari/Microsoft-To-Do-Export) - Import tasks from Microsoft ToDo.
 - [Import from OmniFocus](https://github.com/auino/omnifocus-to-superproductivity) - Import tasks from OmniFocus.
 - [GNOME Shell Extension](https://github.com/ademb2/gnome-shell-extension-super-productivity) - Minimal top panel indicator that displays your current active task and time spent today.
+- [Local Bridge (Go)](https://github.com/CameronBrooks11/super-productivity-local-gobridge) - Single-binary MCP server and CLI over the Local REST API. 16 tools for tasks, projects and tags; no plugin or Node runtime required. Includes a store integrity check (`doctor --deep`) and deliberately exposes no delete operation.
 
 ## Community
 


### PR DESCRIPTION
Adds the Go Local Bridge to **Integrations**.

## What it is

A single static binary that speaks MCP over stdio and doubles as a CLI, talking
to Super Productivity through the official Local REST API. 16 tools covering
tasks, projects and tags.

## Why Integrations rather than Plugins

The Plugins section is generated from
[`community-plugins.json`](https://github.com/super-productivity/super-productivity/blob/master/src/assets/community-plugins.json),
and this is not a plugin — there is nothing to upload and no third-party plugin
to trust, because it only uses the REST API. Integrations is where the
comparable non-plugin tools sit (the GNOME Shell extension, the importers), so
that seemed the right home. Happy to move it if you would rather it went in the
generated list instead.

## Checklist

- Related to Super Productivity — yes, it is a client for its Local REST API
- Not already in the list — correct, this is its first entry
- Working link — https://github.com/CameronBrooks11/super-productivity-local-gobridge
- Brief description — included, one line, matching the section's format
- Added at the bottom of the relevant section, `[Title](URL) - Description.`
- One pull request, one resource

## Context

Shared originally in
[discussion #7895](https://github.com/super-productivity/super-productivity/discussions/7895),
where @johannesjo suggested explaining how it differs from the existing tools —
answered there. Short version: the other MCP servers route through a plugin,
this one uses only the REST API and ships without a runtime.

Its `doctor --deep` store-integrity check is what turned up
super-productivity/super-productivity#9945 and #9946.

*This PR description was drafted with the help of an AI LLM model and checked
over by me before submitting.*
